### PR TITLE
Manufacturerモデルとシードデータを追加

### DIFF
--- a/app/models/manufacturer.rb
+++ b/app/models/manufacturer.rb
@@ -1,0 +1,2 @@
+class Manufacturer < ApplicationRecord
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,11 @@ module App
     # 👇 サブディレクトリ内の翻訳ファイルも確実に読み込む
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
 
+    config.generators do |g|
+      g.skip_routes true
+      g.herper false
+      g.test_framework nil
+    end
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/db/migrate/20251231062407_create_manufacturers.rb
+++ b/db/migrate/20251231062407_create_manufacturers.rb
@@ -1,0 +1,9 @@
+class CreateManufacturers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :manufacturers do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_12_25_124212) do
+ActiveRecord::Schema[7.0].define(version: 2025_12_31_062407) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "manufacturers", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,11 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+# Manufacturerのシードデータ
+manufacturers = ['トヨタ', 'ホンダ', '日産', 'マツダ', 'スズキ', 'ダイハツ', 'スバル']
+
+manufacturers.each do |name|
+  Manufacturer.find_or_create_by!(name: name)
+end
+
+puts "#{Manufacturer.count}件のメーカーを登録しました"


### PR DESCRIPTION
## 実装内容
- Manufacturerモデルの作成
  - `name`カラム（string型）を持つ
- マイグレーション実行
- シードデータの作成
  - 7つのメーカー（トヨタ、ホンダ、日産、マツダ、スズキ、ダイハツ、スバル）を登録

## 動作確認
```bash
# シード投入
docker compose exec web rails db:seed
# => 7件のメーカーを登録しました

# データ確認
docker compose exec web rails console
> Manufacturer.count
=> 7
> Manufacturer.pluck(:name)
=> ["トヨタ", "ホンダ", "日産", "マツダ", "スズキ", "ダイハツ", "スバル"]
## 関連issue
close #11 