### PR TITLE
Vehicleモデルの作成とバリデーション設定

### DIFF
--- a/app/models/manufacturer.rb
+++ b/app/models/manufacturer.rb
@@ -1,2 +1,3 @@
 class Manufacturer < ApplicationRecord
+  has_many :vehicles, dependent: :destroy
 end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,0 +1,22 @@
+class Vehicle < ApplicationRecord
+  # アソシエーション
+  belongs_to :user
+  belongs_to :manufacturer
+
+  # enum
+  enum vehicle_type: { normal: 0, hybrid: 1 }
+
+  # バリデーション
+  validates :vehicle_name, presence: true
+  validates :model, presence: true
+  validates :year, presence: true, numericality: { 
+    only_integer: true, 
+    greater_than_or_equal_to: 1900,
+    less_than_or_equal_to: ->(record) { Date.current.year + 1 }
+  }
+  validates :vehicle_type, presence: true
+  validates :current_mileage, presence: true, numericality: { 
+    only_integer: true, 
+    greater_than_or_equal_to: 0 
+  }
+end

--- a/db/migrate/20251231073550_create_vehicles.rb
+++ b/db/migrate/20251231073550_create_vehicles.rb
@@ -1,0 +1,15 @@
+class CreateVehicles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :vehicles do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :manufacturer, null: false, foreign_key: true
+      t.string :vehicle_name, null: false
+      t.string :model, null: false
+      t.integer :year, null: false
+      t.integer :vehicle_type, default: 0, null: false
+      t.integer :current_mileage, default: 0, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_12_31_062407) do
+ActiveRecord::Schema[7.0].define(version: 2025_12_31_073550) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,4 +33,20 @@ ActiveRecord::Schema[7.0].define(version: 2025_12_31_062407) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "vehicles", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "manufacturer_id", null: false
+    t.string "vehicle_name", null: false
+    t.string "model", null: false
+    t.integer "year", null: false
+    t.integer "vehicle_type", default: 0, null: false
+    t.integer "current_mileage", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["manufacturer_id"], name: "index_vehicles_on_manufacturer_id"
+    t.index ["user_id"], name: "index_vehicles_on_user_id"
+  end
+
+  add_foreign_key "vehicles", "manufacturers"
+  add_foreign_key "vehicles", "users"
 end


### PR DESCRIPTION
## 概要
車両情報を管理するVehicleモデルを作成しました。

## 実装内容
### モデルの作成
- Vehicleモデルを作成
- 以下のカラムを追加：
  - `user_id`（外部キー）
  - `manufacturer_id`（外部キー）
  - `vehicle_name`（車両名）
  - `model`（車種名）
  - `year`（年式）
  - `vehicle_type`（車両タイプ）
  - `current_mileage`（現在の走行距離）

### アソシエーション
- `belongs_to :user`
- `belongs_to :manufacturer`

### Enum
- `vehicle_type: { normal: 0, hybrid: 1 }`

### バリデーション
- `vehicle_name`: 必須
- `model`: 必須
- `year`: 必須、整数、1900年以上、来年まで
- `vehicle_type`: 必須
- `current_mileage`: 必須、整数、0以上

## 動作確認
- Railsコンソールでデータの作成に成功
- バリデーションが正しく動作することを確認

## 備考
- 年式のバリデーションで、動的に「来年まで」を許可するためにラムダを使用
- ラムダは引数を受け取る形（`->(record) { ... }`）で実装

## 関連Issue
Closes #12 