### PR TITLE
車両登録機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ gem "bootsnap", require: false
 
 gem 'devise'
 
+gem 'enum_help'
+
 # 国際化・日本語化
 gem 'rails-i18n', '~> 7.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,8 @@ GEM
       responders
       warden (~> 1.2.3)
     drb (2.2.3)
+    enum_help (0.0.20)
+      activesupport (>= 3.0.0)
     erb (4.0.4)
       cgi (>= 0.3.3)
     erubi (1.13.1)
@@ -264,6 +266,7 @@ DEPENDENCIES
   capybara
   debug
   devise
+  enum_help
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  add_flash_types :success, :danger, :info, :warning
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected

--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -1,0 +1,30 @@
+class VehiclesController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @vehicle = Vehicle.new
+    @manufacturers = Manufacturer.all
+  end
+
+  def create
+    @vehicle = current_user.vehicles.build(vehicle_params)
+
+    if @vehicle.save
+      redirect_to vehicle_path(@vehicle), success: t('vehicles.create.success', item: Vehicle.model_name.human)
+    else
+      flash.now[:danger] = t('defaults.flash_message.not_created', item: Vehicle.model_name.human)
+      @manufacturers = Manufacturer.all
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def show
+    @vehicle = current_user.vehicles.find(params[:id])
+  end
+
+  private
+
+  def vehicle_params
+    params.require(:vehicle).permit(:manufacturer_id, :vehicle_name, :model, :year, :vehicle_type, :current_mileage)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,20 @@
 module ApplicationHelper
+  def flash_class(message_type)
+    case message_type.to_sym
+    when :notice
+      'success'  # 緑色
+    when :alert
+      'danger'   # 赤色
+    when :success
+      'success'  # 緑色
+    when :danger
+      'danger'   # 赤色
+    when :info
+      'info'     # 青色
+    when :warning
+      'warning'  # 黄色
+    else
+      'secondary' # グレー
+    end
+  end
 end

--- a/app/helpers/vehicles_helper.rb
+++ b/app/helpers/vehicles_helper.rb
@@ -1,0 +1,2 @@
+module VehiclesHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   validates :name, presence: true, length: { maximum: 255 }
+  has_many :vehicles, dependent: :destroy
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,9 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-  
+
+    <%= link_to '車両登録', new_vehicle_path %>
+
     <% if user_signed_in? %>
       <p>ようこそ、<%= current_user.email %>さん</p>
       <%= button_to 'ログアウト', destroy_user_session_path, method: :delete %>
@@ -18,12 +20,10 @@
   </head>
 
   <body>
-    <% if notice %>
-      <p class="notice"><%= notice %></p>
-    <% end %>
-    <% if alert %>
-      <p class="alert"><%= alert %></p>
-    <% end %>
+     <!-- フラッシュメッセージを表示 -->
+    <div class="container mt-3">
+      <%= render 'shared/flash_message' %>
+    </div>
 
     <%= yield %>
   </body>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,6 @@
+<% flash.each do |message_type, message| %>
+  <div class="alert alert-<%= message_type %> alert-dismissible fade show" role="alert">
+    <%= message %>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  </div>
+<% end %>

--- a/app/views/vehicles/create.html.erb
+++ b/app/views/vehicles/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Vehicles#create</h1>
+<p>Find me in app/views/vehicles/create.html.erb</p>

--- a/app/views/vehicles/new.html.erb
+++ b/app/views/vehicles/new.html.erb
@@ -1,0 +1,59 @@
+<div class="container">
+  <h1><%= t('vehicles.new.title') %></h1>
+
+  <%= form_with(model: @vehicle) do |form| %>
+    <% if @vehicle.errors.any? %>
+      <div class="alert alert-danger">
+        <h4><%= @vehicle.errors.count %>件のエラーがあります</h4>
+        <ul>
+          <% @vehicle.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="mb-3">
+      <%= form.label :manufacturer_id, 'メーカー', class: 'form-label' %>
+      <%= form.collection_select :manufacturer_id, @manufacturers, :id, :name, 
+          { prompt: 'メーカーを選択してください' }, 
+          { class: 'form-select' } %>
+    </div>
+
+    <div class="mb-3">
+      <%= form.label :vehicle_name, '車両名', class: 'form-label' %>
+      <%= form.text_field :vehicle_name, class: 'form-control' %>
+    </div>
+
+    <div class="mb-3">
+      <%= form.label :model, '車種名', class: 'form-label' %>
+      <%= form.text_field :model, class: 'form-control' %>
+    </div>
+
+    <div class="mb-3">
+      <%= form.label :year, '年式', class: 'form-label' %>
+      <%= form.number_field :year, class: 'form-control' %>
+    </div>
+
+    <div class="mb-3">
+      <%= form.label :vehicle_type, '車両タイプ', class: 'form-label' %>
+      <div>
+        <%= form.radio_button :vehicle_type, 'normal', id: 'vehicle_type_normal', class: 'form-check-input' %>
+        <%= form.label :vehicle_type_normal, '通常車', class: 'form-check-label' %>
+      </div>
+      <div>
+        <%= form.radio_button :vehicle_type, 'hybrid', id: 'vehicle_type_hybrid', class: 'form-check-input' %>
+        <%= form.label :vehicle_type_hybrid, 'ハイブリッド車', class: 'form-check-label' %>
+      </div>
+    </div>
+
+    <div class="mb-3">
+      <%= form.label :current_mileage, '現在の走行距離', class: 'form-label' %>
+      <%= form.number_field :current_mileage, class: 'form-control' %>
+    </div>
+
+    <div class="actions">
+      <%= form.submit class: 'btn btn-primary' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/vehicles/show.html.erb
+++ b/app/views/vehicles/show.html.erb
@@ -1,0 +1,31 @@
+<div class="container mt-4">
+  <h1><%= t('vehicles.show.title') %></h1>
+
+  <div class="card mt-3">
+    <div class="card-body">
+      <dl class="row">
+        <dt class="col-sm-3">メーカー:</dt>
+        <dd class="col-sm-9"><%= @vehicle.manufacturer.name %></dd>
+
+        <dt class="col-sm-3">車両名:</dt>
+        <dd class="col-sm-9"><%= @vehicle.vehicle_name %></dd>
+
+        <dt class="col-sm-3">車種名:</dt>
+        <dd class="col-sm-9"><%= @vehicle.model %></dd>
+
+        <dt class="col-sm-3">年式:</dt>
+        <dd class="col-sm-9"><%= @vehicle.year %></dd>
+
+        <dt class="col-sm-3">車両タイプ:</dt>
+        <dd class="col-sm-9"><%= I18n.t("activerecord.attributes.vehicle.vehicle_types.#{@vehicle.vehicle_type}") %></dd>
+
+        <dt class="col-sm-3">現在の走行距離:</dt>
+        <dd class="col-sm-9"><%= number_with_delimiter(@vehicle.current_mileage) %> km</dd>
+      </dl>
+    </div>
+  </div>
+
+  <div class="mt-3">
+    <%= link_to '戻る', root_path, class: 'btn btn-secondary' %>
+  </div>
+</div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,10 +1,31 @@
 ja:
   activerecord:
     models:
-      user: ユーザー
+      vehicle: "車両"
+      manufacturer: "メーカー"
     attributes:
-      user:
-        email: メールアドレス
-        name: 名前
-        password: パスワード
-        password_confirmation: パスワード確認
+      vehicle:
+        manufacturer: "メーカー"
+        vehicle_name: "車両名"
+        model: "車種名"
+        year: "年式"
+        vehicle_type: "車両タイプ"
+        vehicle_types:
+          normal: "ガソリン車"
+          hybrid: "ハイブリッド車"
+        current_mileage: "現在の走行距離"
+      manufacturer:
+        name: "メーカー名"
+    errors:
+      messages:
+        blank: を入力してください
+        not_a_number: を数値で入力してください
+      models:
+        vehicle:
+          attributes:
+            year:
+              blank: を入力してください
+              not_a_number: を数値で入力してください
+            current_mileage:
+              blank: を入力してください
+              not_a_number: を数値で入力してください

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,27 @@
+ja:
+  helpers:
+    submit:
+      create: 登録
+      submit: 保存
+      update: 更新
+  
+  defaults:
+    flash_message:
+      created: "%{item}を作成しました"
+      not_created: "%{item}を作成出来ませんでした"
+      updated: "%{item}を更新しました"
+      not_updated: "%{item}を更新出来ませんでした"
+      deleted: "%{item}を削除しました"
+      require_login: ログインしてください
+  
+  vehicles:
+    new:
+      title: "車両登録"
+    create:
+      success: "%{item}を登録しました"
+    show:
+      title: "車両詳細"
+    edit:
+      title: "車両編集"
+    index:
+      title: "車両一覧"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root 'static_pages#top'
 
+  resources :vehicles, only: [:new, :create, :show]
   # 👇 この行を追加（後で車両一覧ページに変更予定）
   # root "home#index"  # ← 今は仮で設定
 end


### PR DESCRIPTION
## 概要
ユーザーが自分の車両情報を登録できる機能を実装しました。

## 実装内容

### モデル
- `Vehicle`モデルの作成
  - メーカー、車両名、車種名、年式、車両タイプ、現在の走行距離を管理
  - `vehicle_type`をenumで実装（normal: ガソリン車、hybrid: ハイブリッド車）

### コントローラー
- `VehiclesController`の作成
  - `new`: 車両登録フォームの表示
  - `create`: 車両情報の保存
  - `show`: 車両詳細の表示

### ビュー
- 車両登録フォームの作成
  - メーカー選択（プルダウン）
  - 車両名（テキスト）
  - 車種名（テキスト）
  - 年式（数値）
  - 車両タイプ（ラジオボタン：ガソリン車/ハイブリッド車）
  - 現在の走行距離（数値）
- 車両詳細ページの作成
  - 登録した車両情報の表示
  - 走行距離の3桁区切り表示

### i18n
- 車両関連の日本語化対応
  - モデル名、属性名の日本語化
  - enumの日本語化（ガソリン車/ハイブリッド車）

### その他
- ヘッダーに「車両登録」ボタンを追加
- 登録成功時のフラッシュメッセージ表示
- 登録後は車両詳細ページへリダイレクト

## 確認方法

1. ヘッダーの「車両登録」ボタンをクリック
2. フォームに必要事項を入力して送信
3. 車両詳細ページで登録内容が正しく表示されることを確認
4. 走行距離が3桁区切りで表示されることを確認
5. 車両タイプが日本語（ガソリン車/ハイブリッド車）で表示されることを確認

## 備考

- YAMLのキー名の重複を避けるため、enum値は`vehicle_types`（複数形）で定義
- 走行距離は`number_with_delimiter`ヘルパーを使用して3桁区切り表示

Closes #13 