### PR TITLE
車両詳細・一覧表示機能の実装

### DIFF
--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -1,5 +1,11 @@
 class VehiclesController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_vehicle, only: [:show, :edit, :update, :destroy]
+
+
+  def index
+    @vehicles = current_user.vehicles.all
+  end
 
   def new
     @vehicle = Vehicle.new
@@ -19,10 +25,32 @@ class VehiclesController < ApplicationController
   end
 
   def show
-    @vehicle = current_user.vehicles.find(params[:id])
+  end
+
+  def edit
+    @manufacturers = Manufacturer.all
+  end
+
+  def update
+    if @vehicle.update(vehicle_params)
+      redirect_to vehicle_path(@vehicle), success: t('defaults.flash_message.updated', item: Vehicle.model_name.human)
+    else
+      flash.now[:danger] = t('defaults.flash_message.not_updated', item: Vehicle.model_name.human)
+      @manufacturers = Manufacturer.all
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @vehicle.destroy!
+    redirect_to vehicles_path, success: t('defaults.flash_message.deleted', item: Vehicle.model_name.human), status: :see_other
   end
 
   private
+  
+  def set_vehicle
+    @vehicle = current_user.vehicles.find(params[:id])
+  end
 
   def vehicle_params
     params.require(:vehicle).permit(:manufacturer_id, :vehicle_name, :model, :year, :vehicle_type, :current_mileage)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,24 +7,48 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-
-    <%= link_to '車両登録', new_vehicle_path %>
-
-    <% if user_signed_in? %>
-      <p>ようこそ、<%= current_user.email %>さん</p>
-      <%= button_to 'ログアウト', destroy_user_session_path, method: :delete %>
-    <% else %>
-      <%= link_to 'ログイン', new_user_session_path %>
-      <%= link_to '新規登録', new_user_registration_path %>
-    <% end %>
   </head>
 
   <body>
-     <!-- フラッシュメッセージを表示 -->
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <div class="container-fluid">
+        <%= link_to 'CarMaintenanceReminder', root_path, class: 'navbar-brand' %>
+        
+        <div class="collapse navbar-collapse">
+          <ul class="navbar-nav ms-auto">
+            <% if user_signed_in? %>
+              <li class="nav-item">
+                <%= link_to '車両一覧', vehicles_path, class: 'nav-link' %>
+              </li>
+              <li class="nav-item">
+                <%= link_to '車両登録', new_vehicle_path, class: 'nav-link' %>
+              </li>
+              <li class="nav-item">
+                <span class="nav-link">ようこそ、<%= current_user.email %>さん</span>
+              </li>
+              <li class="nav-item">
+                <%= button_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'btn btn-outline-danger' %>
+              </li>
+            <% else %>
+              <li class="nav-item">
+                <%= link_to 'ログイン', new_user_session_path, class: 'nav-link' %>
+              </li>
+              <li class="nav-item">
+                <%= link_to '新規登録', new_user_registration_path, class: 'nav-link' %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    <!-- フラッシュメッセージを表示 -->
     <div class="container mt-3">
       <%= render 'shared/flash_message' %>
     </div>
 
-    <%= yield %>
+    <div class="container mt-4">
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,31 +1,28 @@
 <div class="top-page">
   <!-- ヘッダー -->
   <header class="header">
-    <h1 class="logo">Mechanicare</h1>
-    <nav>
-      <a href="/login" class="btn-login">ログイン</a>
-    </nav>
+    <h1 class="logo"><%= t('.app_name') %></h1>
   </header>
 
   <!-- メインビジュアル -->
   <section class="hero">
-    <%= image_tag 'car_image.jpg', alt: '車のイメージ', class: 'hero-image' %>
-    <h2>オイル交換を忘れない</h2>
-    <p>車のメンテナンス記録を簡単に管理</p>
+    <%= image_tag 'car_image.jpg', alt: t('.car_image_alt'), class: 'hero-image' %>
+    <h2><%= t('.hero_title') %></h2>
+    <p><%= t('.hero_subtitle') %></p>
   </section>
 
   <!-- アプリの説明 -->
   <section class="features">
-    <h3>Mechanicareの特徴</h3>
+    <h3><%= t('.features_title') %></h3>
     <ul>
-      <li>オイル交換時期を自動で通知</li>
-      <li>メンテナンス履歴を記録</li>
-      <li>車両情報を一元管理</li>
+      <li><%= t('.feature_1') %></li>
+      <li><%= t('.feature_2') %></li>
+      <li><%= t('.feature_3') %></li>
     </ul>
   </section>
 
   <!-- フッター -->
   <footer class="footer">
-    <p>&copy; 2025 Mechanicare</p>
+    <p>&copy; <%= Time.current.year %><%= t('.app_name') %></p>
   </footer>
 </div>

--- a/app/views/vehicles/_form.html.erb
+++ b/app/views/vehicles/_form.html.erb
@@ -1,0 +1,55 @@
+<%= form_with(model: vehicle, local: true) do |form| %>
+  <% if vehicle.errors.any? %>
+    <div class="alert alert-danger">
+      <h4><%= vehicle.errors.count %>件のエラーがあります</h4>
+      <ul>
+        <% vehicle.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="mb-3">
+    <%= form.label :manufacturer_id, t('activerecord.attributes.vehicle.manufacturer'), class: 'form-label' %>
+    <%= form.collection_select :manufacturer_id, @manufacturers, :id, :name, 
+        { prompt: t('defaults.select_prompt') }, 
+        { class: 'form-select' } %>
+  </div>
+
+  <div class="mb-3">
+    <%= form.label :vehicle_name, t('activerecord.attributes.vehicle.vehicle_name'), class: 'form-label' %>
+    <%= form.text_field :vehicle_name, class: 'form-control' %>
+  </div>
+
+  <div class="mb-3">
+    <%= form.label :model, t('activerecord.attributes.vehicle.model'), class: 'form-label' %>
+    <%= form.text_field :model, class: 'form-control' %>
+  </div>
+
+  <div class="mb-3">
+    <%= form.label :year, t('activerecord.attributes.vehicle.year'), class: 'form-label' %>
+    <%= form.number_field :year, class: 'form-control' %>
+  </div>
+
+  <div class="mb-3">
+    <%= form.label :vehicle_type, t('activerecord.attributes.vehicle.vehicle_type'), class: 'form-label' %>
+    <div class="form-check">
+      <%= form.radio_button :vehicle_type, 'normal', id: 'vehicle_type_normal', class: 'form-check-input' %>
+      <%= form.label :vehicle_type_normal, t('activerecord.attributes.vehicle.vehicle_types.normal'), class: 'form-check-label' %>
+    </div>
+    <div class="form-check">
+      <%= form.radio_button :vehicle_type, 'hybrid', id: 'vehicle_type_hybrid', class: 'form-check-input' %>
+      <%= form.label :vehicle_type_hybrid, t('activerecord.attributes.vehicle.vehicle_types.hybrid'), class: 'form-check-label' %>
+    </div>
+  </div>
+
+  <div class="mb-3">
+    <%= form.label :current_mileage, t('activerecord.attributes.vehicle.current_mileage'), class: 'form-label' %>
+    <%= form.number_field :current_mileage, class: 'form-control' %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit class: 'btn btn-primary' %>
+  </div>
+<% end %>

--- a/app/views/vehicles/edit.html.erb
+++ b/app/views/vehicles/edit.html.erb
@@ -1,0 +1,9 @@
+<div class="container mt-5">
+  <h1><%= t('vehicles.edit.title') %></h1>
+
+  <%= render 'form', vehicle: @vehicle %>
+
+  <div class="mt-3">
+    <%= link_to t('.back'), vehicle_path(@vehicle), class: 'btn btn-secondary' %>
+  </div>
+</div>

--- a/app/views/vehicles/index.html.erb
+++ b/app/views/vehicles/index.html.erb
@@ -1,0 +1,21 @@
+<div class="container pt-5">
+  <h1><%= t('.title') %></h1>
+  
+  <div class="row">
+    <% @vehicles.each do |vehicle| %>
+      <div class="col-md-6 mb-3">
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title"><%= vehicle.vehicle_name %></h5>
+            <p class="card-text">
+              <%= t('.manufacturer') %>: <%= vehicle.manufacturer.name %><br>
+              <%= t('.model') %>: <%= vehicle.model %><br>
+              <%= t('.year') %>: <%= vehicle.year %><%= t('.year_unit') %>
+            </p>
+            <%= link_to t('.show_details'), vehicle_path(vehicle), class: 'btn btn-primary' %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/vehicles/new.html.erb
+++ b/app/views/vehicles/new.html.erb
@@ -1,59 +1,9 @@
-<div class="container">
+<div class="container mt-5">
   <h1><%= t('vehicles.new.title') %></h1>
 
-  <%= form_with(model: @vehicle) do |form| %>
-    <% if @vehicle.errors.any? %>
-      <div class="alert alert-danger">
-        <h4><%= @vehicle.errors.count %>件のエラーがあります</h4>
-        <ul>
-          <% @vehicle.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
+  <%= render 'form', vehicle: @vehicle %>
 
-    <div class="mb-3">
-      <%= form.label :manufacturer_id, 'メーカー', class: 'form-label' %>
-      <%= form.collection_select :manufacturer_id, @manufacturers, :id, :name, 
-          { prompt: 'メーカーを選択してください' }, 
-          { class: 'form-select' } %>
-    </div>
-
-    <div class="mb-3">
-      <%= form.label :vehicle_name, '車両名', class: 'form-label' %>
-      <%= form.text_field :vehicle_name, class: 'form-control' %>
-    </div>
-
-    <div class="mb-3">
-      <%= form.label :model, '車種名', class: 'form-label' %>
-      <%= form.text_field :model, class: 'form-control' %>
-    </div>
-
-    <div class="mb-3">
-      <%= form.label :year, '年式', class: 'form-label' %>
-      <%= form.number_field :year, class: 'form-control' %>
-    </div>
-
-    <div class="mb-3">
-      <%= form.label :vehicle_type, '車両タイプ', class: 'form-label' %>
-      <div>
-        <%= form.radio_button :vehicle_type, 'normal', id: 'vehicle_type_normal', class: 'form-check-input' %>
-        <%= form.label :vehicle_type_normal, '通常車', class: 'form-check-label' %>
-      </div>
-      <div>
-        <%= form.radio_button :vehicle_type, 'hybrid', id: 'vehicle_type_hybrid', class: 'form-check-input' %>
-        <%= form.label :vehicle_type_hybrid, 'ハイブリッド車', class: 'form-check-label' %>
-      </div>
-    </div>
-
-    <div class="mb-3">
-      <%= form.label :current_mileage, '現在の走行距離', class: 'form-label' %>
-      <%= form.number_field :current_mileage, class: 'form-control' %>
-    </div>
-
-    <div class="actions">
-      <%= form.submit class: 'btn btn-primary' %>
-    </div>
-  <% end %>
+  <div class="mt-3">
+    <%= link_to t('vehicles.new.back'), vehicles_path, class: 'btn btn-secondary' %>
+  </div>
 </div>

--- a/app/views/vehicles/show.html.erb
+++ b/app/views/vehicles/show.html.erb
@@ -1,31 +1,36 @@
 <div class="container mt-4">
-  <h1><%= t('vehicles.show.title') %></h1>
+  <h1><%= t('.title') %></h1>
 
   <div class="card mt-3">
     <div class="card-body">
       <dl class="row">
-        <dt class="col-sm-3">メーカー:</dt>
+        <dt class="col-sm-3"><%= t('.manufacturer') %>:</dt>
         <dd class="col-sm-9"><%= @vehicle.manufacturer.name %></dd>
 
-        <dt class="col-sm-3">車両名:</dt>
+        <dt class="col-sm-3"><%= t('.vehicle_name') %>:</dt>
         <dd class="col-sm-9"><%= @vehicle.vehicle_name %></dd>
 
-        <dt class="col-sm-3">車種名:</dt>
+        <dt class="col-sm-3"><%= t('.model') %>:</dt>
         <dd class="col-sm-9"><%= @vehicle.model %></dd>
 
-        <dt class="col-sm-3">年式:</dt>
+        <dt class="col-sm-3"><%= t('.year') %>:</dt>
         <dd class="col-sm-9"><%= @vehicle.year %></dd>
 
-        <dt class="col-sm-3">車両タイプ:</dt>
+        <dt class="col-sm-3"><%= t('.vehicle_type') %>:</dt>
         <dd class="col-sm-9"><%= I18n.t("activerecord.attributes.vehicle.vehicle_types.#{@vehicle.vehicle_type}") %></dd>
 
-        <dt class="col-sm-3">現在の走行距離:</dt>
+        <dt class="col-sm-3"><%= t('.current_mileage') %>:</dt>
         <dd class="col-sm-9"><%= number_with_delimiter(@vehicle.current_mileage) %> km</dd>
       </dl>
     </div>
   </div>
 
   <div class="mt-3">
-    <%= link_to '戻る', root_path, class: 'btn btn-secondary' %>
+    <%= link_to t('.edit'), edit_vehicle_path(@vehicle), class: 'btn btn-warning' %>
+    <%= button_to t('.delete'), vehicle_path(@vehicle), 
+        method: :delete, 
+        data: { turbo_confirm: t('.delete_confirm') }, 
+        class: 'btn btn-danger' %>
+    <%= link_to t('.back'), vehicles_path, class: 'btn btn-secondary' %>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,4 +1,16 @@
 ja:
+  static_pages:
+    top:
+      app_name: Mechanicare
+      login: ログイン
+      car_image_alt: 車のイメージ
+      hero_title: オイル交換を忘れない
+      hero_subtitle: 車のメンテナンス記録を簡単に管理
+      features_title: Mechanicareの特徴
+      feature_1: オイル交換時期を自動で通知
+      feature_2: メンテナンス履歴を記録
+      feature_3: 車両情報を一元管理
+      copyright: "&copy; %{year} Mechanicare"
   helpers:
     submit:
       create: 登録
@@ -6,6 +18,7 @@ ja:
       update: 更新
   
   defaults:
+    select_prompt: 選択してください
     flash_message:
       created: "%{item}を作成しました"
       not_created: "%{item}を作成出来ませんでした"
@@ -17,11 +30,29 @@ ja:
   vehicles:
     new:
       title: "車両登録"
+      back: 一覧に戻る
     create:
       success: "%{item}を登録しました"
     show:
-      title: "車両詳細"
+      title: 車両詳細
+      manufacturer: メーカー
+      vehicle_name: 車両名
+      model: 車種名
+      year: 年式
+      vehicle_type: 車両タイプ
+      current_mileage: 現在の走行距離
+      mileage_unit: km
+      back: 一覧に戻る
+      edit: 編集
+      delete: 削除
+      delete_confirm: 本当に削除しますか？
     edit:
       title: "車両編集"
+      back: "詳細に戻る"
     index:
-      title: "車両一覧"
+      title: 車両一覧
+      manufacturer: メーカー
+      model: 車種
+      year: 年式
+      year_unit: 年
+      show_details: 詳細を見る

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root 'static_pages#top'
 
-  resources :vehicles, only: [:new, :create, :show]
-  # 👇 この行を追加（後で車両一覧ページに変更予定）
-  # root "home#index"  # ← 今は仮で設定
+  resources :vehicles, only: [:index, :new, :create, :show, :edit, :update, :destroy]
 end


### PR DESCRIPTION
## 概要
車両の詳細情報と一覧を表示する機能を実装しました。

## 実装内容
- VehiclesController#show, index の実装
- 車両詳細ページの作成
  - 車両名、メーカー、車種、年式、車両タイプ、走行距離を表示
  - 「編集」「削除」「戻る」ボタンの配置
- 車両一覧ページの作成
  - 登録済み車両の一覧表示
  - 各車両の詳細ページへのリンク
- ナビゲーションバーに「車両一覧」リンクを追加
  - ログイン後のトップページから車両一覧にアクセス可能

## 動作確認
- [x] 車両詳細ページが正しく表示される
- [x] 車両一覧ページが正しく表示される
- [x] 削除機能が正常に動作する
- [x] トップページから車両一覧へのリンクが機能する
- [x] 車両一覧から詳細ページへのリンクが機能する

## 備考
MVPでは1台のみの想定ですが、将来の拡張を考慮して一覧ページも実装しています。

Closes #14 