### PR TITLE
OilChangeRecordモデルを作成

### DIFF
--- a/app/models/oil_change_record.rb
+++ b/app/models/oil_change_record.rb
@@ -1,0 +1,6 @@
+class OilChangeRecord < ApplicationRecord
+  belongs_to :vehicle
+
+  validates :changed_at, presence: true
+  validates :mileage, presence: true, numericality: { only_integer: true, greater_than: 0 }
+end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -2,6 +2,7 @@ class Vehicle < ApplicationRecord
   # アソシエーション
   belongs_to :user
   belongs_to :manufacturer
+  has_many :oil_change_records, dependent: :destroy
 
   # enum
   enum vehicle_type: { normal: 0, hybrid: 1 }

--- a/db/migrate/20260104075049_create_oil_change_records.rb
+++ b/db/migrate/20260104075049_create_oil_change_records.rb
@@ -1,0 +1,12 @@
+class CreateOilChangeRecords < ActiveRecord::Migration[7.0]
+  def change
+    create_table :oil_change_records do |t|
+      t.references :vehicle, null: false, foreign_key: true
+      t.date :changed_at, null: false
+      t.integer :mileage, null: false
+      t.text :memo
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_12_31_073550) do
+ActiveRecord::Schema[7.0].define(version: 2026_01_04_075049) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,16 @@ ActiveRecord::Schema[7.0].define(version: 2025_12_31_073550) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "oil_change_records", force: :cascade do |t|
+    t.bigint "vehicle_id", null: false
+    t.date "changed_at", null: false
+    t.integer "mileage", null: false
+    t.text "memo"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["vehicle_id"], name: "index_oil_change_records_on_vehicle_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -47,6 +57,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_12_31_073550) do
     t.index ["user_id"], name: "index_vehicles_on_user_id"
   end
 
+  add_foreign_key "oil_change_records", "vehicles"
   add_foreign_key "vehicles", "manufacturers"
   add_foreign_key "vehicles", "users"
 end


### PR DESCRIPTION
## 概要
オイル交換履歴を管理する`OilChangeRecord`モデルを作成しました。

## 実装内容

### 1. OilChangeRecordモデルの作成
- `vehicle_id`（外部キー）
- `changed_at`（交換実施日）
- `mileage`（交換時の走行距離）
- `memo`（メモ・備考）

### 2. アソシエーションの設定
- `OilChangeRecord`に`belongs_to :vehicle`を追加
- `Vehicle`に`has_many :oil_change_records, dependent: :destroy`を追加

### 3. バリデーションの設定
- `changed_at`: 必須
- `mileage`: 必須、正の整数のみ

## 確認方法

### Railsコンソールでの確認

closes #16 