### PR TITLE
add: オイル交換記録登録機能の実装

### DIFF
--- a/app/controllers/oil_change_records_controller.rb
+++ b/app/controllers/oil_change_records_controller.rb
@@ -1,0 +1,28 @@
+class OilChangeRecordsController < ApplicationController
+  before_action :set_vehicle
+
+  def new
+    @oil_change_record = @vehicle.oil_change_records.build
+  end
+
+  def create
+    @oil_change_record = @vehicle.oil_change_records.build(oil_change_record_params)
+
+    if @oil_change_record.save
+      redirect_to vehicle_path(@vehicle), success: t('oil_change_records.create.success')
+    else
+      flash.now[:danger] = t('oil_change_records.create.failure')
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_vehicle
+    @vehicle = current_user.vehicles.find(params[:vehicle_id])
+  end
+
+  def oil_change_record_params
+    params.require(:oil_change_record).permit(:changed_at, :mileage, :memo)
+  end
+end

--- a/app/helpers/oil_change_records_helper.rb
+++ b/app/helpers/oil_change_records_helper.rb
@@ -1,0 +1,2 @@
+module OilChangeRecordsHelper
+end

--- a/app/views/oil_change_records/create.html.erb
+++ b/app/views/oil_change_records/create.html.erb
@@ -1,0 +1,2 @@
+<h1>OilChangeRecords#create</h1>
+<p>Find me in app/views/oil_change_records/create.html.erb</p>

--- a/app/views/oil_change_records/new.html.erb
+++ b/app/views/oil_change_records/new.html.erb
@@ -1,0 +1,25 @@
+<%# app/views/oil_change_records/new.html.erb %>
+<div class="container">
+  <h1><%= t('oil_change_records.new.title') %></h1>
+
+  <%= form_with model: @oil_change_record, url: vehicle_oil_change_records_path(@vehicle), local: true do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
+
+    <div class="mb-3">
+      <%= f.label :changed_at, class: 'form-label' %>
+      <%= f.date_field :changed_at, class: 'form-control' %>
+    </div>
+
+    <div class="mb-3">
+      <%= f.label :mileage, class: 'form-label' %>
+      <%= f.number_field :mileage, class: 'form-control', placeholder: '例: 50000' %>
+    </div>
+
+    <div class="mb-3">
+      <%= f.label :memo, class: 'form-label' %>
+      <%= f.text_area :memo, class: 'form-control', rows: 5, placeholder: 'エンジンオイル交換' %>
+    </div>
+
+    <%= f.submit class: 'btn btn-primary' %>
+  <% end %>
+</div>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,14 @@
+<%# app/views/shared/_error_messages.html.erb %>
+<% if object.errors.any? %>
+  <div class="alert alert-danger alert-dismissible fade show" role="alert">
+    <h5 class="alert-heading">
+      <%= t('errors.template.header', count: object.errors.count, model: object.class.model_name.human) %>
+    </h5>
+    <ul class="mb-0">
+      <% object.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  </div>
+<% end %>

--- a/app/views/vehicles/show.html.erb
+++ b/app/views/vehicles/show.html.erb
@@ -1,6 +1,9 @@
 <div class="container mt-4">
   <h1><%= t('.title') %></h1>
 
+   <%# オイル交換記録を追加ボタン %>
+  <%= link_to t('.oil_change_record'), new_vehicle_oil_change_record_path(@vehicle), class: 'btn btn-primary' %>
+
   <div class="card mt-3">
     <div class="card-body">
       <dl class="row">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       vehicle: "車両"
       manufacturer: "メーカー"
+      oil_change_record: "オイル交換記録"  # ← 追加
     attributes:
       vehicle:
         manufacturer: "メーカー"
@@ -16,6 +17,10 @@ ja:
         current_mileage: "現在の走行距離"
       manufacturer:
         name: "メーカー名"
+      oil_change_record:  # ← 追加(単数形に注意!)
+        changed_at: "交換実施日"
+        mileage: "交換時の走行距離"
+        memo: "メモ"
     errors:
       messages:
         blank: を入力してください

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -35,6 +35,7 @@ ja:
       success: "%{item}を登録しました"
     show:
       title: 車両詳細
+      oil_change_record: オイル交換記録を追加
       manufacturer: メーカー
       vehicle_name: 車両名
       model: 車種名
@@ -56,3 +57,10 @@ ja:
       year: 年式
       year_unit: 年
       show_details: 詳細を見る
+  oil_change_records:
+    new:
+      title: "オイル交換記録を追加"
+      back: "車両詳細に戻る"
+    create:
+      success: "オイル交換記録を登録しました"
+      failure: "オイル交換記録を登録出来ませんでした"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root 'static_pages#top'
 
-  resources :vehicles, only: [:index, :new, :create, :show, :edit, :update, :destroy]
+  resources :vehicles, only: [:index, :new, :create, :show, :edit, :update, :destroy] do
+    resources :oil_change_records, only: [:new, :create]
+  end
 end


### PR DESCRIPTION
## 概要
オイル交換記録を登録できる機能を実装しました。

## 実装内容

### 1. コントローラーの実装
- `OilChangeRecordsController`を作成
  - `new`アクション: フォーム画面を表示
  - `create`アクション: オイル交換記録を登録

### 2. ビューの実装
- オイル交換記録登録フォームを作成
  - 交換実施日(日付選択)
  - 交換時の走行距離(数値入力)
  - メモ(テキストエリア)

### 3. ルーティングの設定
- `vehicles/:vehicle_id/oil_change_records`にネストしたルーティングを設定

### 4. 日本語化対応
- フォームの各項目を日本語化
- エラーメッセージを日本語化
- フラッシュメッセージを日本語化

### 5. 車両詳細ページの更新
- 「オイル交換記録を追加」ボタンを追加

## 動作確認

### 成功時の動作
- ✅ 正しいデータで登録できる
- ✅ 車両詳細ページにリダイレクトされる
- ✅ 「オイル交換記録を登録しました」というメッセージが表示される

### エラー時の動作
- ✅ 空のまま登録しようとするとエラーメッセージが表示される
- ✅ エラーメッセージが日本語で表示される
- ✅ 「オイル交換記録を登録できませんでした」というメッセージが表示される
- ✅ 各項目のエラーが日本語で表示される
- ✅ 入力した値が保持される

### バリデーション
- ✅ 交換実施日が必須
- ✅ 交換時の走行距離が必須
- ✅ 交換時の走行距離が0以上の数値
- ✅ メモは任意

## 関連issue
Closes #17 