### PR TITLE
add: オイル交換記録の一覧機能を実装

### DIFF
--- a/app/controllers/oil_change_records_controller.rb
+++ b/app/controllers/oil_change_records_controller.rb
@@ -1,6 +1,10 @@
 class OilChangeRecordsController < ApplicationController
   before_action :set_vehicle
 
+  def index
+    @oil_change_records = @vehicle.oil_change_records.order(changed_at: :desc)
+  end
+
   def new
     @oil_change_record = @vehicle.oil_change_records.build
   end

--- a/app/views/oil_change_records/index.html.erb
+++ b/app/views/oil_change_records/index.html.erb
@@ -1,0 +1,32 @@
+<div class="container">
+  <h1><%= t('.title', vehicle_name: @vehicle.vehicle_name) %></h1>
+
+  <% if @oil_change_records.any? %>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th><%= t('.changed_at') %></th>
+          <th><%= t('.mileage') %></th>
+          <th><%= t('.memo') %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @oil_change_records.each do |record| %>
+          <tr>
+            <td><%= l record.changed_at, format: :long %></td>
+            <td><%= number_with_delimiter(record.mileage) %> <%= t('.mileage_unit') %></td>
+            <td><%= record.memo %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p><%= t('.no_records') %></p>
+  </div>
+  <% end %>
+
+  <div class="mt-3">
+    <%= link_to t('.back'), (@vehicle), class: 'btn btn-secondary' %>
+    <%= link_to t('.oil_change_record'), new_vehicle_oil_change_record_path(@vehicle), class: 'btn btn-primary' %>
+  </div>
+</div>

--- a/app/views/oil_change_records/new.html.erb
+++ b/app/views/oil_change_records/new.html.erb
@@ -20,6 +20,7 @@
       <%= f.text_area :memo, class: 'form-control', rows: 5, placeholder: 'エンジンオイル交換' %>
     </div>
 
+    <%= link_to t('.back'), (@vehicle), class: 'btn btn-secondary' %>
     <%= f.submit class: 'btn btn-primary' %>
   <% end %>
 </div>

--- a/app/views/vehicles/show.html.erb
+++ b/app/views/vehicles/show.html.erb
@@ -3,6 +3,7 @@
 
    <%# オイル交換記録を追加ボタン %>
   <%= link_to t('.oil_change_record'), new_vehicle_oil_change_record_path(@vehicle), class: 'btn btn-primary' %>
+  <%= link_to 'オイル交換履歴を見る', vehicle_oil_change_records_path(@vehicle), class: 'btn btn-info' %>
 
   <div class="card mt-3">
     <div class="card-body">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -58,6 +58,15 @@ ja:
       year_unit: 年
       show_details: 詳細を見る
   oil_change_records:
+    index:
+      title: "%{vehicle_name}のオイル交換履歴"
+      changed_at: 交換日
+      mileage: 走行距離
+      memo: メモ
+      no_records: まだオイル交換履歴がありません
+      back: 車両詳細に戻る
+      oil_change_record: オイル交換記録を追加
+      mileage_unit: km
     new:
       title: "オイル交換記録を追加"
       back: "車両詳細に戻る"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
   root 'static_pages#top'
 
   resources :vehicles, only: [:index, :new, :create, :show, :edit, :update, :destroy] do
-    resources :oil_change_records, only: [:new, :create]
+    resources :oil_change_records, only: [:index, :new, :create]
   end
 end


### PR DESCRIPTION
## 概要
オイル交換履歴の一覧表示機能を実装しました。



## 実装内容

### 追加機能
- オイル交換履歴一覧ページの作成
  - 日付順（新しい順）でソート表示
  - 交換日、走行距離、メモを表示
- 車両詳細ページから「オイル交換履歴を見る」リンクを追加

### 実装詳細
- **Controller**: `OilChangeRecordsController#index` を実装
- **View**: `oil_change_records/index.html.erb` を作成
- **Routes**: オイル交換履歴一覧へのルーティングを追加

## 動作確認

### 確認項目
- [x] オイル交換履歴一覧ページが表示される
- [x] 新しい日付順に表示される
- [x] 交換日、走行距離、メモが正しく表示される
- [x] 車両詳細ページからのリンクが機能する
- [x] 履歴がない場合の表示も適切

### テスト
- [x] ローカルでの動作確認完了
- [x] 各機能が正常に動作することを確認

Closes #18 