### PR TITLE
Add: 使い方ページの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Car Maintenance Reminder
+# MechaniCare
 
 [![CI](https://github.com/egifufox/car_maintenance_reminder/actions/workflows/ci.yml/badge.svg)](https://github.com/egifufox/car_maintenance_reminder/actions/workflows/ci.yml)
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,4 +4,6 @@ class PagesController < ApplicationController
   def terms; end
 
   def privacy; end
+
+  def guide; end
 end

--- a/app/views/pages/guide.html.erb
+++ b/app/views/pages/guide.html.erb
@@ -1,0 +1,105 @@
+<div class="container">
+  <!-- タイトル -->
+  <div class="mb-4">
+    <h1 class="h3 mb-2">使い方</h1>
+    <p class="text-muted mb-0">4つのステップで、車両メンテナンスを管理できます。</p>
+  </div>
+
+  <!-- ステップ1 -->
+  <div class="card mb-3">
+    <div class="card-body">
+      <div class="d-flex align-items-start">
+        <div class="bg-primary text-white rounded-circle d-flex align-items-center justify-content-center me-3" style="width: 40px; height: 40px; flex-shrink: 0;">
+          <strong>1</strong>
+        </div>
+        <div>
+          <h5 class="card-title mb-2">アカウント登録</h5>
+          <p class="card-text text-muted mb-0">
+            メールアドレスとパスワードで新規登録します。<br>
+            登録後、すぐにご利用いただけます。
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ステップ2 -->
+  <div class="card mb-3">
+    <div class="card-body">
+      <div class="d-flex align-items-start">
+        <div class="bg-primary text-white rounded-circle d-flex align-items-center justify-content-center me-3" style="width: 40px; height: 40px; flex-shrink: 0;">
+          <strong>2</strong>
+        </div>
+        <div>
+          <h5 class="card-title mb-2">車両を登録</h5>
+          <p class="card-text text-muted mb-0">
+            車名、年式、走行距離などの基本情報を入力します。<br>
+            複数の車両を登録できます。
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ステップ3 -->
+  <div class="card mb-3">
+    <div class="card-body">
+      <div class="d-flex align-items-start">
+        <div class="bg-primary text-white rounded-circle d-flex align-items-center justify-content-center me-3" style="width: 40px; height: 40px; flex-shrink: 0;">
+          <strong>3</strong>
+        </div>
+        <div>
+          <h5 class="card-title mb-2">メンテナンス記録を追加</h5>
+          <p class="card-text text-muted mb-0">
+            オイル交換、タイヤ交換、車検などの記録を登録します。<br>
+            日付、走行距離、費用、メモを残せます。
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ステップ4 -->
+  <div class="card mb-3">
+    <div class="card-body">
+      <div class="d-flex align-items-start">
+        <div class="bg-primary text-white rounded-circle d-flex align-items-center justify-content-center me-3" style="width: 40px; height: 40px; flex-shrink: 0;">
+          <strong>4</strong>
+        </div>
+        <div>
+          <h5 class="card-title mb-2">履歴を確認</h5>
+          <p class="card-text text-muted mb-0">
+            車両詳細ページで過去の記録を一覧表示できます。<br>
+            次回のメンテナンス時期の目安も確認できます。
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- よくある質問 -->
+  <div class="mt-5">
+    <h4 class="mb-3">よくある質問</h4>
+
+    <div class="card mb-3">
+      <div class="card-body">
+        <h6 class="card-title">Q. 複数の車両を登録できますか？</h6>
+        <p class="card-text text-muted mb-0">A. はい、制限なく複数の車両を登録できます。</p>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <div class="card-body">
+        <h6 class="card-title">Q. データは安全ですか?</h6>
+        <p class="card-text text-muted mb-0">A. はい、定期的にバックアップを行っています。</p>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <div class="card-body">
+        <h6 class="card-title">Q. スマートフォンでも使えますか?</h6>
+        <p class="card-text text-muted mb-0">A. はい、レスポンシブデザインで快適に使えます。</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,23 +1,65 @@
 <div class="container">
-  <h1>プライバシーポリシー</h1>
-  
-  <section>
-    <h2>個人情報の取得</h2>
-    <p>
-      当サイトでは、ユーザー登録の際にメールアドレスなどの
-      個人情報をご登録いただく場合があります。
-    </p>
-  </section>
+  <!-- タイトル -->
+  <div class="mb-4">
+    <h1 class="h3 mb-2">プライバシーポリシー</h1>
+  </div>
 
-  <section>
-    <h2>個人情報の利用目的</h2>
-    <p>
-      取得した個人情報は、以下の目的で利用いたします。
-    </p>
-    <ul>
-      <li>サービスの提供・運営のため</li>
-      <li>ユーザーからのお問い合わせに対応するため</li>
-      <li>利用規約に違反したユーザーへの対応のため</li>
-    </ul>
-  </section>
+  <!-- 個人情報の取得 -->
+  <div class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title">個人情報の取得</h5>
+      <p class="card-text text-muted mb-0">
+        当サイトでは、ユーザー登録の際にメールアドレスなどの個人情報をご登録いただく場合があります。
+      </p>
+    </div>
+  </div>
+
+  <!-- 個人情報の利用目的 -->
+  <div class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title">個人情報の利用目的</h5>
+      <p class="card-text text-muted mb-2">
+        取得した個人情報は、以下の目的で利用いたします。
+      </p>
+      <ul class="text-muted mb-0">
+        <li>サービスの提供・運営のため</li>
+        <li>ユーザーからのお問い合わせに対応するため</li>
+        <li>利用規約に違反したユーザーへの対応のため</li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- 個人情報の第三者提供 -->
+  <div class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title">個人情報の第三者提供</h5>
+      <p class="card-text text-muted mb-0">
+        当サイトは、個人情報を適切に管理し、以下のいずれかに該当する場合を除き、個人情報を第三者に開示いたしません。
+      </p>
+      <ul class="text-muted mb-0">
+        <li>ユーザーの同意がある場合</li>
+        <li>法令に基づき開示することが必要である場合</li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- 個人情報の開示 -->
+  <div class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title">個人情報の開示</h5>
+      <p class="card-text text-muted mb-0">
+        当サイトは、ユーザーご本人からの個人情報の開示、訂正、追加、削除、利用停止のご希望の場合には、ご本人であることを確認させていただいた上、速やかに対応させていただきます。
+      </p>
+    </div>
+  </div>
+
+  <!-- プライバシーポリシーの変更 -->
+  <div class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title">プライバシーポリシーの変更</h5>
+      <p class="card-text text-muted mb-0">
+        当サイトは、個人情報に関して適用される日本の法令を遵守するとともに、本ポリシーの内容を適宜見直しその改善に努めます。修正された最新のプライバシーポリシーは常に本ページにて開示されます。
+      </p>
+    </div>
+  </div>
 </div>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,47 +1,71 @@
 <div class="container">
-  <h1>利用規約</h1>
-  
-  <p>
-    本サービス「CarMaintenanceReminder」（以下「本サービス」）をご利用いただくにあたり、
-    以下の利用規約（以下「本規約」）に同意いただく必要があります。
-  </p>
-
-  <section>
-    <h2>第1条（禁止事項）</h2>
-    <p>本サービスの利用にあたり、以下の行為を禁止します。</p>
-    <ul>
-      <li>法令または公序良俗に違反する行為</li>
-      <li>本サービスの運営を妨害する行為</li>
-      <li>不正アクセスをし、またはこれを試みる行為</li>
-      <li>他のユーザーに迷惑をかける行為</li>
-      <li>その他、運営者が不適切と判断する行為</li>
-    </ul>
-  </section>
-
-  <section>
-    <h2>第2条（免責事項）</h2>
-    <p>
-      本サービスは個人によって運営されており、
-      サービスの内容や動作について保証するものではありません。
-      本サービスの利用によって生じた損害について、
-      運営者は一切の責任を負いません。
+  <!-- タイトル -->
+  <div class="mb-4">
+    <h1 class="h3 mb-2">利用規約</h1>
+    <p class="text-muted mb-0">
+      本サービス「MechaniCare」（以下「本サービス」）をご利用いただくにあたり、以下の利用規約（以下「本規約」）に同意いただく必要があります。
     </p>
-  </section>
+  </div>
 
-  <section>
-    <h2>第3条（個人情報の取扱い）</h2>
-    <p>
-      本サービスで取得した個人情報は、プライバシーポリシーに従い適切に管理します。
-    </p>
-  </section>
+  <!-- 第1条（禁止事項） -->
+  <div class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title">第1条（禁止事項）</h5>
+      <p class="card-text text-muted mb-2">
+        本サービスの利用にあたり、以下の行為を禁止します。
+      </p>
+      <ul class="text-muted mb-0">
+        <li>法令または公序良俗に違反する行為</li>
+        <li>本サービスの運営を妨害する行為</li>
+        <li>不正アクセスをし、またはこれを試みる行為</li>
+        <li>他のユーザーに迷惑をかける行為</li>
+        <li>その他、運営者が不適切と判断する行為</li>
+      </ul>
+    </div>
+  </div>
 
-  <section>
-    <h2>第4条（規約の変更）</h2>
-    <p>
-      運営者は、必要に応じて本規約を変更することがあります。
-      変更後の規約は、本サービス上に掲載した時点で効力を生じます。
-    </p>
-  </section>
+  <!-- 第2条（免責事項） -->
+  <div class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title">第2条（免責事項）</h5>
+      <p class="card-text text-muted mb-0">
+        本サービスは個人によって運営されており、サービスの内容や動作について保証するものではありません。本サービスの利用によって生じた損害について、運営者は一切の責任を負いません。
+      </p>
+    </div>
+  </div>
 
-  <p class="mt-4 text-end">制定日：<%= Time.current.year %>年<%= Time.current.month %>月<%= Time.current.day %>日</p>
+  <!-- 第3条（個人情報の取扱い） -->
+  <div class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title">第3条（個人情報の取扱い）</h5>
+      <p class="card-text text-muted mb-0">
+        本サービスで取得した個人情報は、プライバシーポリシーに従い適切に管理します。詳細は<%= link_to "プライバシーポリシー", privacy_path %>をご確認ください。
+      </p>
+    </div>
+  </div>
+
+  <!-- 第4条（規約の変更） -->
+  <div class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title">第4条（規約の変更）</h5>
+      <p class="card-text text-muted mb-0">
+        運営者は、必要に応じて本規約を変更することがあります。変更後の規約は、本サービス上に掲載した時点で効力を生じます。
+      </p>
+    </div>
+  </div>
+
+  <!-- 第5条（準拠法・裁判管轄） -->
+  <div class="card mb-3">
+    <div class="card-body">
+      <h5 class="card-title">第5条（準拠法・裁判管轄）</h5>
+      <p class="card-text text-muted mb-0">
+        本規約の解釈にあたっては、日本法を準拠法とします。本サービスに関して紛争が生じた場合には、運営者の所在地を管轄する裁判所を専属的合意管轄とします。
+      </p>
+    </div>
+  </div>
+
+  <!-- 制定日 -->
+  <div class="text-end text-muted mb-3">
+    <small>制定日：<%= Time.current.year %>年<%= Time.current.month %>月<%= Time.current.day %>日</small>
+  </div>
 </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -2,7 +2,7 @@
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fw-bold">
     <%= link_to root_path, class: "navbar-brand", style: "margin-left: 120px;" do %>
       <i class="bi bi-car-front"></i>
-      CarMaintenanceReminder
+      MechaniCare
     <% end %>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,8 +2,10 @@
   <div class='container mt-3'>
     <div class='row'>
       <div class='text-white text-center mt-2'>
-        <p>&copy; <%= Time.current.year %> CarMaintenanceReminder. All rights reserved.</p>
+        <p>&copy; <%= Time.current.year %> MechaniCare. All rights reserved.</p>
         <nav class="mt-2 mb-3">
+          <%= link_to '使い方', guide_path, class: 'text-white text-decoration-none mx-2 hover-opacity' %>
+          <span class="text-white">|</span>
           <%= link_to '利用規約', terms_path, class: 'text-white text-decoration-none mx-2 hover-opacity' %>
           <span class="text-white">|</span>
           <%= link_to 'プライバシーポリシー', privacy_path, class: 'text-white text-decoration-none mx-2 hover-opacity' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,7 +2,7 @@
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark fw-bold">
     <span class="navbar-brand" style="margin-left: 120px;">
       <i class="bi bi-car-front"></i>
-      CarMaintenanceReminder
+      MechaniCare
     </span>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,4 +17,7 @@ Rails.application.routes.draw do
   # 利用規約・プライバシーポリシー
   get 'terms', to: 'pages#terms'
   get 'privacy', to: 'pages#privacy'
+
+  # 利用規約・プライバシーポリシー
+  get 'guide', to: 'pages#guide'
 end


### PR DESCRIPTION
## 概要
使い方ページを追加しました。

## 変更内容
- **ルーティングの追加**
  - `/guide` - 使い方ページ
  - `/privacy_policy` - プライバシーポリシーページをBootstrap のカードデザインに変更
  - `/terms` - 利用規約ページをBootstrap のカードデザインに変更

- **コントローラーの作成**
  - 使い方ページに対応するアクションを定義

- **ビューの作成**
  - `app/views/pages/guide.html.erb` - 使い方ページ
  - Bootstrap のカードデザインで統一

- **フッターの更新**
  - 各ページへのリンクを追加

## 確認方法
1. `http://localhost:3000/guide` にアクセスして使い方ページを確認
2. `http://localhost:3000/privacy_policy` にアクセスしてプライバシーポリシーページを確認
3. `http://localhost:3000/terms` にアクセスして利用規約ページを確認
4. フッターのリンクから各ページに遷移できることを確認

## その他
- 未ログイン状態でもアクセス可能

Closes #59 