### PR TITLE
GitHub Actionsで自動デプロイを設定

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,20 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Trigger Render Deploy
+        env:
+          RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          curl -X POST $RENDER_DEPLOY_HOOK_URL

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ https://car-maintenance-reminder.onrender.com
 - ✅ 使い方ページ
 - ✅ CI/CD環境（GitHub Actions）
 - ✅ コード品質管理（Rubocop）
+- ✅ 静的OGP設定
 
 ### **今後実装予定の機能**
 - [ ] パスワードリセット機能
@@ -68,7 +69,6 @@ https://car-maintenance-reminder.onrender.com
 - [ ] ダッシュボード機能（今月やるべきメンテナンス一覧）
 - [ ] 車種別メンテナンス推奨項目
 - [ ] Googleログイン機能
-- [ ] 静的OGP設定
 - [ ] 独自ドメイン設定
 
 ## 使用技術


### PR DESCRIPTION
## 概要
GitHub Actions を使って、mainブランチへのプッシュ時に自動でRenderにデプロイする機能を実装しました。

## 実装内容
- `.github/workflows/cd.yml` を作成
- mainブランチへのプッシュ時にRenderのDeploy Hook URLにPOSTリクエストを送信
- GitHub SecretsにRenderのDeploy Hook URLを登録

## 動作確認方法
1. このプルリクエストをmainブランチにマージ
2. GitHub Actionsが自動で実行されることを確認
3. Renderで自動デプロイが開始されることを確認

Closes #62 