### PR TITLE
ログイン状態を保持する機能を実装

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -164,17 +164,18 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  # ログイン状態を保持する期間（デフォルトは2週間）
+  config.remember_for = 2.weeks
 
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true
 
   # If true, extends the user's remember period when remembered via cookie.
-  # config.extend_remember_period = false
+  config.extend_remember_period = false
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.
-  # config.rememberable_options = {}
+  config.rememberable_options = {}
 
   # ==> Configuration for :validatable
   # Range for password length.


### PR DESCRIPTION
## 概要
ログイン時に「ログイン状態を保持する」チェックボックスをオンにすることで、ブラウザを閉じても2週間ログイン状態が保持される機能を実装しました。

## 変更内容
- User モデルに `:rememberable` を追加
- マイグレーションで `remember_created_at` カラムを追加
- ログインフォームに「ログイン状態を保持する」チェックボックスを追加
- Google OAuth ログイン時も `remember_me` を適用

## 動作確認
- [x] チェックボックスをオンにしてログイン後、ブラウザを閉じて再度開いた際にログイン状態が保持されることを確認
- [x] チェックボックスをオフにしてログイン後、ブラウザを閉じて再度開いた際にログイン状態が保持されないことを確認

## 補足
- シークレットモードではブラウザを閉じると Cookie が削除されるため、通常のブラウザで動作確認を行いました

Closes #66 