### PR TITLE
パスワードリセット機能の実装

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,10 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= @resource.email %> 様</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>パスワード再設定のリクエストを受け付けました。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p>以下のリンクからパスワードを変更してください。</p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= link_to 'パスワードを変更する', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>※このリクエストに心当たりがない場合は、このメールを無視してください。</p>
+<p>※上記のリンクにアクセスして新しいパスワードを設定するまで、パスワードは変更されません。</p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,42 @@
-<h2>change your password</h2>
+<% content_for(:title, 'パスワード変更') %>
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-5 col-lg-3">
+      <div class="card">
+        <div class="card-body"> 
+          <h1 class="card-title text-center">パスワード変更</h1>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+          <p class="text-center text-muted mb-4">
+            新しいパスワードを入力してください
+          </p>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+          <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+            <%= render "devise/shared/error_messages", resource: resource %>
+            <%= f.hidden_field :reset_password_token %>
+
+            <div class="mb-3">
+              <%= f.label :password, '新しいパスワード' %>
+              <% if @minimum_password_length %>
+                <small class="text-muted">（<%= @minimum_password_length %>文字以上）</small>
+              <% end %>
+              <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "form-control mt-1", placeholder: "新しいパスワード" %>
+            </div>
+
+            <div class="mb-3">
+              <%= f.label :password_confirmation, '新しいパスワード（確認）' %>
+              <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control mt-1", placeholder: "新しいパスワードを再入力" %>
+            </div>
+
+            <div class="d-grid">
+              <%= f.submit 'パスワードを変更する', class: "btn btn-primary" %>
+            </div>
+          <% end %>
+
+          <div class='text-center mt-3'>
+            <%= link_to 'ログインページへ戻る', new_user_session_path, class: "link" %>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,39 @@
-<h2><%= t('devise.passwords.new.title') %></h2>
+<% content_for(:title, t('devise.passwords.new.title')) %>
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-5 col-lg-3">
+      <div class="card">
+          <div class="card-body"> 
+            <h1 class="card-title text-center" style="font-size: 2.0rem;">パスワードの再設定</h1>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+              <p class="text-center text-muted mb-4">
+  登録されているメールアドレスを<br>
+  入力してください
+</p>
 
-  <div class="field">
-    <%= f.label :email, t('devise.passwords.new.email') %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+          <!-- パスワードリセットフォーム -->
+          <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+            <%= render "devise/shared/error_messages", resource: resource %>
+
+            <div class="mb-3">
+              <%= f.label :email, 'メールアドレス' %>
+              <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control mt-1", placeholder: "user@example.com" %>
+            </div>
+
+            <div class="d-grid">
+              <%= f.submit 'パスワードリセットメールを送信', class: "btn btn-primary" %>
+            </div>
+          <% end %>
+
+          <div class='text-center mt-3'>
+            <%= link_to 'ログインページへ戻る', new_user_session_path, class: "link" %>
+          </div>
+
+          <div class='text-center mt-2'>
+            <%= link_to 'アカウントをお持ちでない方はこちら', new_user_registration_path, class: "link" %>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit t('devise.passwords.new.submit') %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, t('.title')) %>
 <div class="container">
   <div class="row justify-content-center">
-    <div class=" col-md-5 col-lg-3">
+    <div class="col-md-5 col-lg-3">
       <div class="card">
         <div class="card-body"> 
           <h1 class="card-title text-center">ログイン</h1>
@@ -43,9 +43,13 @@
             </div>
           <% end %>
  
-          <div class='text-center mt-2'>
+          <div class='text-center mt-3'>
             <%= link_to 'アカウントをお持ちでない方はこちら', new_user_registration_path, class: "link" %>
           </div>                
+
+          <div class='text-center mt-3'>
+            <%= link_to 'パスワードをお忘れの方はこちら', new_user_password_path, class: "link" %>
+          </div>
         </div>
       </div>
     </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,6 +71,8 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
   config.action_mailer.default_url_options = { host: ENV['MAILER_HOST'], protocol: 'https' }
+
+  config.action_mailer.default_options = { from: ENV['MAILER_FROM_ADDRESS'] || 'noreply@car-maintenance-reminder.onrender.com' }
   
   config.action_mailer.smtp_settings = {
     address: 'smtp.sendgrid.net',

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,9 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # メールの送信元アドレスを設定
+  config.mailer_sender = ENV.fetch('MAILER_FROM_ADDRESS', 'noreply@car-maintenance-reminder.onrender.com')
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
## 実装内容
- パスワードリセット機能の実装
- パスワード変更フォームをログインページと同じデザインに統一

## 確認方法
1. パスワードリセット申請: `http://localhost:3000/users/password/new`
2. メール確認: `http://localhost:3000/letter_opener`
3. パスワード変更: メール内のリンクからアクセス
4. 新しいパスワードでログイン確認

## 動作確認
- [x] ローカル環境で動作確認済み
- [ ] Render環境で動作確認予定

Closes #37 