### PR TITLE
feat: オイル交換リマインドメール機能を実装

### DIFF
--- a/app/mailers/oil_change_reminder_mailer.rb
+++ b/app/mailers/oil_change_reminder_mailer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class OilChangeReminderMailer < ApplicationMailer
+  # オイル交換リマインドメールを送信
+  def reminder(user, vehicle)
+    @user = user
+    @vehicle = vehicle
+    @km_until_next_oil_change = vehicle.km_until_next_oil_change
+    @days_until_next_oil_change = vehicle.days_until_next_oil_change
+
+    mail(
+      to: @user.email,
+      subject: "【MechaniCare】#{@vehicle.vehicle_name}のオイル交換時期が近づいています"
+    )
+  end
+end

--- a/app/views/oil_change_reminder_mailer/reminder.html.erb
+++ b/app/views/oil_change_reminder_mailer/reminder.html.erb
@@ -1,0 +1,21 @@
+<h1>こんにちは、<%= @user.name %>さん</h1>
+
+<p><strong><%= @vehicle.vehicle_name %></strong> のオイル交換時期が近づいています。</p>
+
+<h2>次回交換時期</h2>
+<ul>
+  <% if @km_until_next_oil_change.present? %>
+    <li>走行距離ベース: あと<strong><%= @km_until_next_oil_change %> km</strong></li>
+  <% end %>
+  <% if @days_until_next_oil_change.present? %>
+    <li>期間ベース: あと<strong><%= @days_until_next_oil_change %>日</strong></li>
+  <% end %>
+</ul>
+
+<p>早めのメンテナンスをおすすめします!</p>
+
+<p>
+  <%= link_to '車両詳細を確認する', vehicle_url(@vehicle), style: 'display: inline-block; padding: 10px 20px; background-color: #007bff; color: white; text-decoration: none; border-radius: 5px;' %>
+</p>
+
+<p>MechaniCare</p>

--- a/app/views/oil_change_reminder_mailer/reminder.text.erb
+++ b/app/views/oil_change_reminder_mailer/reminder.text.erb
@@ -1,0 +1,17 @@
+こんにちは、<%= @user.name %>さん
+
+<%= @vehicle.vehicle_name %> のオイル交換時期が近づいています。
+
+次回交換時期:
+<% if @km_until_next_oil_change.present? %>
+- 走行距離ベース: あと<%= @km_until_next_oil_change %> km
+<% end %>
+<% if @days_until_next_oil_change.present? %>
+- 期間ベース: あと<%= @days_until_next_oil_change %>日
+<% end %>
+
+早めのメンテナンスをおすすめします!
+
+車両詳細を確認する: <%= vehicle_url(@vehicle) %>
+
+MechaniCare

--- a/app/views/vehicles/new.html.erb
+++ b/app/views/vehicles/new.html.erb
@@ -21,10 +21,10 @@
 
           <!-- メーカー -->
           <div class="m-3">
-            <%= f.label :manufacturer_id, 'メーカー' %>
+            <%= f.label :manufacturer_id, 'メーカー', for: 'vehicle_manufacturer_id' %>
             <%= f.collection_select :manufacturer_id, @manufacturers, :id, :name, 
-                { prompt: '選択してください' }, 
-                { class: 'form-select mt-2' } %>
+                  { prompt: '選択してください' }, 
+                  { class: 'form-select mt-2', id: 'vehicle_manufacturer_id' } %>
           </div>
 
           <!-- 車両名 -->
@@ -47,15 +47,15 @@
 
           <!-- 車両タイプ -->
           <div class="m-3">
-            <%= f.label :vehicle_type, '車両タイプ' %>
+            <label>車両タイプ</label>
             <div class="mt-2">
               <div class="form-check form-check-inline">
                 <%= f.radio_button :vehicle_type, 'normal', id: 'vehicle_type_normal', class: 'form-check-input' %>
-                <%= f.label :vehicle_type_normal, 'ガソリン車', class: 'form-check-label' %>
+                <%= label_tag 'vehicle_type_normal', 'ガソリン車', class: 'form-check-label' %>
               </div>
               <div class="form-check form-check-inline">
                 <%= f.radio_button :vehicle_type, 'hybrid', id: 'vehicle_type_hybrid', class: 'form-check-input' %>
-                <%= f.label :vehicle_type_hybrid, 'ハイブリッド車', class: 'form-check-label' %>
+                <%= label_tag 'vehicle_type_hybrid', 'ハイブリッド車', class: 'form-check-label' %>
               </div>
             </div>
           </div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,6 +43,9 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # メールのURLホストを設定
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/lib/tasks/oil_change_reminder.rake
+++ b/lib/tasks/oil_change_reminder.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+namespace :oil_change do
+  desc 'オイル交換時期が近い車両のオーナーにメールを送信'
+  task send_reminders: :environment do
+    # オイル交換時期が近い車両を取得
+    vehicles = Vehicle.includes(:user, :oil_change_records).select(&:needs_oil_change_soon?)
+
+    vehicles.each do |vehicle|
+      # メール送信
+      OilChangeReminderMailer.reminder(vehicle.user, vehicle).deliver_now
+      puts "メール送信: #{vehicle.user.email} (#{vehicle.vehicle_name})"
+    end
+
+    puts "送信完了: #{vehicles.count}件"
+  end
+end

--- a/spec/mailers/oil_change_reminder_mailer_spec.rb
+++ b/spec/mailers/oil_change_reminder_mailer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OilChangeReminderMailer, type: :mailer do
+  describe 'reminder' do
+    let(:user) { create(:user, email: 'test@example.com', name: 'テストユーザー') }
+    let(:vehicle) { create(:vehicle, user: user, vehicle_name: 'テスト車両') }
+    let(:mail) { OilChangeReminderMailer.reminder(user, vehicle) }
+
+    it 'メールの宛先が正しいこと' do
+      expect(mail.to).to eq(['test@example.com'])
+    end
+
+    it 'メールの件名が正しいこと' do
+      expect(mail.subject).to eq('【MechaniCare】テスト車両のオイル交換時期が近づいています')
+    end
+
+    it 'メール本文にユーザー名が含まれていること' do
+      # ✅ HTML部分を取得して検証
+      expect(mail.html_part.body.to_s).to include(user.name)
+    end
+
+    it 'メール本文に車両名が含まれていること' do
+      # ✅ HTML部分を取得して検証
+      expect(mail.html_part.body.to_s).to include(vehicle.vehicle_name)
+    end
+  end
+end

--- a/spec/tasks/oil_change_reminder_spec.rb
+++ b/spec/tasks/oil_change_reminder_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'oil_change:send_reminders', type: :task do
+  before do
+    Rake.application.rake_require 'tasks/oil_change_reminder'
+    Rake::Task.define_task(:environment)
+
+    # ✅ テスト前にデータをクリーンアップ
+    OilChangeRecord.destroy_all
+    Vehicle.destroy_all
+    User.destroy_all
+  end
+
+  it 'メール送信が実行されること' do
+    # テストデータを作成
+    user = create(:user, email: 'test@example.com', name: 'テストユーザー')
+    vehicle = create(:vehicle, user: user, vehicle_name: 'テスト車両')
+
+    # オイル交換記録を作成(オイル交換時期が近い状態にする)
+    create(:oil_change_record,
+           vehicle: vehicle,
+           mileage: vehicle.current_mileage - 4500, # 残り500kmでリマインダー
+           changed_at: 6.months.ago)
+
+    task = Rake::Task['oil_change:send_reminders']
+    task.reenable
+
+    # メール送信が1件実行されることを確認
+    expect { task.invoke }.to change { ActionMailer::Base.deliveries.count }.by(1)
+  end
+end


### PR DESCRIPTION
## 概要
オイル交換時期が近づいたユーザーに対して、自動でリマインドメールを送信する機能を実装しました。

## 実装内容

### 機能
- オイル交換時期が近づいたユーザーに対して、メールで通知を送信
- メールはHTML形式とテキスト形式の両方に対応（マルチパート）
- Rakeタスクを実行することで、対象ユーザーに一括でメールを送信

### リマインド条件
以下のいずれかの条件を満たす車両のユーザーに通知を送信します:
- 前回のオイル交換から **6ヶ月以上** 経過している
- 前回のオイル交換から **5,000km以上** 走行している

### 実装したファイル
- `app/mailers/oil_change_reminder_mailer.rb` - メーラークラス
- `app/views/oil_change_reminder_mailer/reminder.html.erb` - HTML形式のメールテンプレート
- `app/views/oil_change_reminder_mailer/reminder.text.erb` - テキスト形式のメールテンプレート
- `lib/tasks/oil_change_reminder.rake` - メール送信を実行するRakeタスク
- `spec/mailers/oil_change_reminder_mailer_spec.rb` - メーラーのテスト
- `spec/tasks/oil_change_reminder_spec.rb` - Rakeタスクのテスト

## テスト
- RSpecによるテストを実装し、全て通過していることを確認
- Rubocopによるコードチェックも実施

### テスト実行結果
```bash
# メーラーのテスト
docker compose exec web bundle exec rspec spec/mailers/oil_change_reminder_mailer_spec.rb
# => 4 examples, 0 failures

# Rakeタスクのテスト
docker compose exec web bundle exec rspec spec/tasks/oil_change_reminder_spec.rb
# => 1 example, 0 failures

# 全体のテスト
docker compose exec web bundle exec rspec
# => 5 examples, 0 failures

# Rubocop
docker compose exec web bundle exec rubocop
# => no offenses detected